### PR TITLE
docs: label reporium-db 826-repo launch scale as historical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@
 ## [1.0.0] - 2026-03-17
 
 ### Added
-- Nightly GitHub metadata sync via GraphQL batch fetch (9 calls for 826 repos)
+- March 2026 launch snapshot: nightly GitHub metadata sync via GraphQL batch fetch (9 calls for the initial 826-repo corpus)
 - Partitioned JSON output: index.json, by_language, by_category, full/repos_NNNN.json
 - Schedule-based tiering: nightly for active, weekly for moderate, monthly for inactive
 - Diff computation: tracks new and updated repos between runs
 - LAST_RUN.md generated after each sync with real metrics
+
+### Notes
+- The 826-repo figure above is a historical launch milestone from 2026-03-17, not the current nightly sync scale.


### PR DESCRIPTION
## Summary
- mark the 826-repo GraphQL sync figure as a March 2026 launch snapshot
- make the changelog explicit that current nightly scale is documented elsewhere

## Validation
- python -m pytest tests -q
- verified remaining 826 references in README.md and CHANGELOG.md are historical only

## Follow-up
- after review/merge to dev, open promotion PR from dev to main