### PR TITLE
fix: retry GitHub secondary-rate-limit 403s in nightly sync

### DIFF
--- a/reporium_db/fetcher.py
+++ b/reporium_db/fetcher.py
@@ -98,13 +98,49 @@ def _save_checkpoint(started_at: str, cursor: Optional[str], count: int) -> None
     os.replace(tmp, CHECKPOINT_FILE)
 
 
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a Retry-After header value into seconds when possible."""
+    if not value:
+        return None
+    try:
+        return max(float(value), 0.0)
+    except ValueError:
+        return None
+
+
+def _is_retryable_403(resp: httpx.Response) -> bool:
+    """Treat GitHub secondary-rate-limit style 403s as retryable."""
+    if resp.status_code != 403:
+        return False
+
+    retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+    remaining = resp.headers.get("X-RateLimit-Remaining")
+    body = resp.text.lower()
+
+    return (
+        retry_after is not None
+        or remaining == "0"
+        or "secondary rate limit" in body
+        or "abuse detection" in body
+        or "please wait a few minutes before you try again" in body
+    )
+
+
+def _retry_delay_seconds(resp: httpx.Response, attempt: int) -> float:
+    """Honor Retry-After when present, otherwise use bounded exponential backoff."""
+    retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+    if retry_after is not None:
+        return min(retry_after, 30.0)
+    return min(2**attempt + 0.1 * attempt, 30.0)
+
+
 async def _graphql_request(
     client: httpx.AsyncClient,
     token: str,
     variables: dict[str, Any],
     attempt: int = 0,
 ) -> dict[str, Any]:
-    """Execute a GraphQL POST with exponential backoff on 429/502/503 (max 4 attempts)."""
+    """Execute a GraphQL POST with retry on transient transport and throttling errors."""
     headers = {"Authorization": f"bearer {token}", "Content-Type": "application/json"}
     try:
         resp = await client.post(
@@ -121,11 +157,16 @@ async def _graphql_request(
         await asyncio.sleep(wait)
         return await _graphql_request(client, token, variables, attempt + 1)
 
-    if resp.status_code in (429, 502, 503):
+    if resp.status_code in (429, 502, 503) or _is_retryable_403(resp):
         if attempt >= 3:
             resp.raise_for_status()
-        wait = 2**attempt + 0.1 * attempt
-        logger.warning("HTTP %d (attempt %d) — retry in %.1fs", resp.status_code, attempt + 1, wait)
+        wait = _retry_delay_seconds(resp, attempt)
+        logger.warning(
+            "HTTP %d (attempt %d) — retry in %.1fs",
+            resp.status_code,
+            attempt + 1,
+            wait,
+        )
         await asyncio.sleep(wait)
         return await _graphql_request(client, token, variables, attempt + 1)
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -124,6 +124,45 @@ async def test_fetch_retries_502():
 
 
 @respx.mock
+async def test_fetch_retries_secondary_rate_limit_403():
+    """Retries on GitHub secondary-rate-limit 403s and eventually succeeds."""
+    route = respx.post(GRAPHQL_URL)
+    route.side_effect = [
+        httpx.Response(
+            403,
+            headers={"Retry-After": "3"},
+            text="You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+        ),
+        httpx.Response(200, json=_page([_node("retry-403")], False)),
+    ]
+
+    with patch("asyncio.sleep") as mock_sleep:
+        repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert len(repos) == 1
+    assert repos[0].name == "retry-403"
+    mock_sleep.assert_called_with(3.0)
+
+
+@respx.mock
+async def test_fetch_does_not_retry_non_rate_limit_403():
+    """Fails fast on permanent 403s that do not signal throttling."""
+    respx.post(GRAPHQL_URL).mock(
+        return_value=httpx.Response(403, text="Resource not accessible by integration")
+    )
+
+    with patch("asyncio.sleep") as mock_sleep:
+        try:
+            await fetch_all_repos(TEST_CONFIG)
+        except httpx.HTTPStatusError as exc:
+            assert exc.response.status_code == 403
+        else:
+            raise AssertionError("Expected HTTPStatusError for non-retryable 403")
+
+    mock_sleep.assert_not_called()
+
+
+@respx.mock
 async def test_fetch_checkpoint_resume(tmp_path):
     """Resumes from a valid checkpoint file."""
     ckpt = tmp_path / "checkpoints" / "current_run.json"


### PR DESCRIPTION
## Summary
- retry GitHub GraphQL secondary-rate-limit and retry-after 403 responses during nightly sync fetches
- keep permanent 403 responses as hard failures
- add fetcher tests covering retryable and non-retryable 403 behavior

## Why
Issue #3 captured a nightly sync failure on 2026-03-22 where the GraphQL fetch failed with HTTP 403 partway through the run. The workflow is green again today, but the fetcher still treated all 403s as fatal. This patch hardens the exact failure mode seen in the logs without changing successful paths.

## Validation
- `python -m pytest tests/test_fetcher.py -q`
- `python -m pytest tests -q`