### PR TITLE
sync: bump _MAX_RETRIES from 6 to 10 (absorb sustained GraphQL 502s)

### DIFF
--- a/reporium_db/fetcher.py
+++ b/reporium_db/fetcher.py
@@ -24,13 +24,16 @@ CHECKPOINT_FILE = Path("checkpoints/current_run.json")
 _RATE_LIMIT_TOTAL = 5000  # GitHub authenticated GraphQL points/hour
 
 # GraphQL 502/503/504 from GitHub are common transient failures — especially
-# during incidents or peak traffic. 3 attempts (old default) covers occasional
-# blips but not a multi-minute degradation. 6 attempts with jittered
-# exponential backoff buys us ~5 minutes of resilience per request before
-# giving up, at which point the checkpoint-resume path kicks in on the next
-# run. See 2026-04-22 incident in reporium-db Nightly Sync (06:57 UTC GraphQL
-# 502 with only 3 attempts → hard fail).
-_MAX_RETRIES = 6
+# during incidents or peak traffic. History:
+#   - 3 attempts (original): single-blip hard fail, see 2026-04-22 incident.
+#   - 6 attempts (KAN-…): ~5 min of resilience.
+#   - 10 attempts (2026-05-12): 4 of 7 nightlies failed in the week ending
+#     2026-05-12 (May 7, 8, 11, 12 all red on sustained 502s). Bumping to 10
+#     buys ~17 min of resilience (2+4+8+16+32+64+128+256+300+300 ≈ 17 min
+#     given the 300s cap at the tail). Recovers from the typical multi-minute
+#     GitHub GraphQL outage pattern without changing the failure mode for a
+#     genuine multi-hour outage (checkpoint resume still kicks in on next run).
+_MAX_RETRIES = 10
 _RETRYABLE_STATUS = (429, 500, 502, 503, 504)
 
 QUERY = """


### PR DESCRIPTION
## Summary

4 of 7 nightly sync runs failed in the week ending 2026-05-12 (May 7, 8, 11, 12 — all red on GitHub GraphQL 502s). Existing 6-retry budget exhausts at ~5 min of resilience; recent incident patterns are running longer.

Bumping \`_MAX_RETRIES\` from 6 to 10 buys ~17 min of total backoff (2+4+8+16+32+64+128+256+300+300 ≈ 17 min, given the 300s ceiling at the tail).

## Evidence

\`gh run list --workflow=sync.yml --limit 7\` for perditioinc/reporium-db:

| Date | Conclusion |
|------|------------|
| 2026-05-12 07:43Z | failure (502) |
| 2026-05-11 08:24Z | failure (502) |
| 2026-05-10 07:26Z | success |
| 2026-05-09 07:09Z | success |
| 2026-05-08 06:52Z | failure (502) |
| 2026-05-07 07:43Z | failure (502) |
| 2026-05-06 07:35Z | success |

Today's stack trace (run 25720737332) shows \`_graphql_request\` exhausting its 6-retry budget then \`resp.raise_for_status()\` at fetcher.py:187.

## Change

\`reporium_db/fetcher.py\`: \`_MAX_RETRIES = 6\` → \`10\`. Comment updated to record the rationale and the prior history (3 → 6 → 10).

Nothing else changes: backoff curve, retryable status codes, Retry-After honouring, secondary-rate-limit 403 handling, and checkpoint resume on hard failure are all unchanged.

## Risk

- Larger retry budget burns more time before declaring failure. With the 300s ceiling, the tail attempts are already bounded.
- If GitHub is genuinely down for >17 min, behaviour is identical to today: hard fail → checkpoint resume on next run.

## Test plan

- [ ] CI green on this branch.
- [ ] After merge, the next scheduled sync_yml run (tomorrow 07:00 UTC) lands green if today's 502 was the same multi-minute incident pattern. If 502 returns and exhausts the new budget too, escalate to a workflow-level retry layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)