### PR TITLE
test: harden checkpoint resume, pagination, scheduler boundaries, partition contract

### DIFF
--- a/reporium_db/fetcher.py
+++ b/reporium_db/fetcher.py
@@ -129,6 +129,35 @@ def _save_checkpoint(started_at: str, cursor: Optional[str], count: int) -> None
     os.replace(tmp, CHECKPOINT_FILE)
 
 
+def _clear_checkpoint() -> None:
+    """Best-effort removal of the checkpoint after a fully successful fetch.
+
+    Deleting the checkpoint is a cleanup, not a correctness operation: a
+    leftover checkpoint is < 24h old and resumable, and resume is idempotent
+    (the cursor is saved AFTER it advances, so the next run fetches the NEXT
+    page, never re-counting). A transient OS-level lock on the file - Windows
+    holds a brief share lock during antivirus scans / indexing, and concurrent
+    readers can keep the handle open - must therefore NOT turn an otherwise
+    green sync RED. Swallow the file-system errors that mean "already gone" or
+    "momentarily locked"; the < 24h staleness check cleans it up next run.
+    """
+    try:
+        CHECKPOINT_FILE.unlink()
+    except FileNotFoundError:
+        # Already removed (e.g. concurrent run, or never written for a
+        # single-page fetch). Nothing to do.
+        pass
+    except OSError as exc:
+        # PermissionError [WinError 5/32] and friends: the file exists but is
+        # momentarily locked. Leaving it is safe - it is resumable and will be
+        # aged out on the next run - so log and continue rather than fail.
+        logger.warning(
+            "Could not remove checkpoint %s (leaving it for next run to age out): %s",
+            CHECKPOINT_FILE,
+            exc,
+        )
+
+
 def _parse_retry_after(value: str | None) -> float | None:
     """Parse a Retry-After header value into seconds when possible."""
     if not value:
@@ -320,8 +349,7 @@ async def fetch_all_repos(config: Config) -> tuple[list[RepoMetadata], dict[str,
             # with the old (pre-advance) cursor which double-counted on resume.
             _save_checkpoint(started_at, cursor, len(repos))
 
-    if CHECKPOINT_FILE.exists():
-        CHECKPOINT_FILE.unlink()
+    _clear_checkpoint()
 
     elapsed = time.monotonic() - t0
     logger.info("Fetch complete: %d repos in %.1fs (%d API calls)", len(repos), elapsed, api_calls)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,29 @@ from __future__ import annotations
 
 import pytest
 
+import reporium_db.fetcher as fetcher
 from reporium_db.models import RepoMetadata
+
+
+@pytest.fixture(autouse=True)
+def isolate_checkpoint(tmp_path, monkeypatch):
+    """Redirect the fetcher checkpoint to a per-test tmp path.
+
+    The fetcher writes ``checkpoints/current_run.json`` (a relative path) on
+    every multi-page fetch. Without this isolation, tests would write a real
+    checkpoint into the repo working tree - a data artifact that must never be
+    committed - and collide with each other on Windows, where a momentarily
+    locked file makes ``os.replace`` / ``unlink`` raise PermissionError and the
+    multi-page test flakes red. Pinning the checkpoint under ``tmp_path`` per
+    test makes the suite hermetic and deterministic on every OS.
+
+    Tests that need to drive the checkpoint explicitly (e.g. a pre-seeded
+    resume file) may still ``monkeypatch``/``patch`` ``fetcher.CHECKPOINT_FILE``
+    themselves; this fixture just supplies a safe default.
+    """
+    monkeypatch.setattr(
+        fetcher, "CHECKPOINT_FILE", tmp_path / "checkpoints" / "current_run.json"
+    )
 
 
 def make_repo(

--- a/tests/test_fetcher_checkpoint.py
+++ b/tests/test_fetcher_checkpoint.py
@@ -1,0 +1,277 @@
+"""Checkpoint-cache resilience tests for the GraphQL fetcher.
+
+These cover the durable-resume contract that the nightly sync depends on:
+
+  * a sustained GitHub-side 502 exhausts the retry budget and raises, but
+    leaves the checkpoint on disk so the NEXT run resumes instead of cold
+    restarting (the live failure mode documented in fetcher.py);
+  * resuming from a checkpoint starts at the saved cursor (the NEXT page), so
+    the merge across two runs is idempotent and never double-counts;
+  * the checkpoint is written with the post-advance cursor on every page;
+  * a transient lock on the checkpoint at cleanup time does NOT fail an
+    otherwise-successful sync (cross-platform robustness, Windows in CI).
+
+All GraphQL traffic is mocked with respx; no network, keys, or cloud are used.
+The autouse ``isolate_checkpoint`` fixture (conftest) pins CHECKPOINT_FILE to a
+per-test tmp path, so nothing here writes a checkpoint into the repo tree.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+import reporium_db.fetcher as fetcher
+from reporium_db.config import Config
+from reporium_db.fetcher import _MAX_RETRIES, GRAPHQL_URL, fetch_all_repos
+
+TEST_CONFIG = Config(
+    gh_token="test-token",
+    gh_username="testuser",
+    concurrency_graphql=5,
+    rate_limit_threshold=0.8,
+    checkpoint_interval=1000,
+    nightly_tier_days=30,
+    weekly_tier_days=365,
+)
+
+
+def _page(nodes, has_next, cursor="c1", remaining=4000):
+    return {
+        "data": {
+            "repositoryOwner": {
+                "repositories": {
+                    "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                    "nodes": nodes,
+                }
+            },
+            "rateLimit": {"remaining": remaining, "resetAt": "2026-03-17T06:00:00Z", "cost": 1},
+        }
+    }
+
+
+def _node(name):
+    return {
+        "nameWithOwner": f"testuser/{name}",
+        "name": name,
+        "description": "desc",
+        "stargazerCount": 5,
+        "forkCount": 1,
+        "primaryLanguage": {"name": "Python"},
+        "pushedAt": "2026-03-01T00:00:00Z",
+        "updatedAt": "2026-03-01T00:00:00Z",
+        "createdAt": "2025-01-01T00:00:00Z",
+        "isArchived": False,
+        "isFork": False,
+        "isEmpty": False,
+        "parent": None,
+        "repositoryTopics": {"nodes": []},
+        "licenseInfo": {"name": "MIT"},
+        "issues": {"totalCount": 0},
+        "defaultBranchRef": {"name": "main"},
+    }
+
+
+# -- checkpoint persistence on sustained-502 (durable resume across runs) ------
+
+
+@respx.mock
+async def test_sustained_502_leaves_resumable_checkpoint(tmp_path):
+    """A sustained 502 raises but leaves the checkpoint for the NEXT run.
+
+    Run 1 fetches page 1 (advancing + saving the checkpoint with the page-2
+    cursor) then hits an unrecoverable 502 on page 2. The checkpoint file must
+    survive the raise so a follow-up run can resume - this is the documented
+    durable-resume fix, and the whole point of writing the checkpoint per page.
+    """
+    ckpt = tmp_path / "checkpoints" / "current_run.json"
+    page1 = _page([_node("a")], has_next=True, cursor="page2-cursor")
+
+    responses = [httpx.Response(200, json=page1)]
+    responses += [httpx.Response(502)] * (_MAX_RETRIES + 2)  # exhaust page-2 budget
+    route = respx.post(GRAPHQL_URL)
+    route.side_effect = responses
+
+    with patch.object(fetcher, "CHECKPOINT_FILE", ckpt):
+        with patch("asyncio.sleep"):
+            with pytest.raises(httpx.HTTPStatusError) as excinfo:
+                await fetch_all_repos(TEST_CONFIG)
+
+    assert excinfo.value.response.status_code == 502
+    # The checkpoint must STILL be on disk (resume path), pointing at page 2.
+    assert ckpt.exists(), "checkpoint must survive a hard 502 for the next run"
+    saved = json.loads(ckpt.read_text())
+    assert saved["last_cursor"] == "page2-cursor"
+    assert saved["repos_processed"] == 1
+
+
+@respx.mock
+async def test_resume_starts_at_saved_cursor_no_double_count(tmp_path):
+    """Resuming uses the saved cursor as ``after`` and merges idempotently.
+
+    Run 1 saved a checkpoint at ``page2-cursor`` after persisting page 1's repo
+    in a *prior* process. Run 2 (this one) must POST with after=page2-cursor and
+    return ONLY page-2 repos - it must not re-fetch page 1. The combined view
+    across runs therefore has no duplicates: the merge is idempotent.
+    """
+    ckpt = tmp_path / "checkpoints" / "current_run.json"
+    ckpt.parent.mkdir(parents=True)
+    ckpt.write_text(
+        json.dumps(
+            {
+                # < 24h old so the checkpoint is honored
+                "started_at": datetime.now(timezone.utc).isoformat(),
+                "last_cursor": "page2-cursor",
+                "repos_processed": 1,
+            }
+        )
+    )
+
+    captured = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        captured["after"] = body["variables"]["after"]
+        return httpx.Response(200, json=_page([_node("b")], has_next=False))
+
+    respx.post(GRAPHQL_URL).mock(side_effect=_handler)
+
+    with patch.object(fetcher, "CHECKPOINT_FILE", ckpt):
+        repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert meta["resumed"] is True
+    # The first (only) request resumed from the saved cursor, not from None.
+    assert captured["after"] == "page2-cursor"
+    # Only page-2 repos are fetched this run; page 1 is NOT re-fetched.
+    assert [r.name for r in repos] == ["b"]
+    # Successful completion clears the checkpoint.
+    assert not ckpt.exists()
+
+
+@respx.mock
+async def test_checkpoint_saved_with_post_advance_cursor(tmp_path):
+    """Each saved checkpoint stores the NEXT page's cursor, not the current one.
+
+    Saving the pre-advance cursor would re-fetch the just-processed page on
+    resume and double-count. We assert the checkpoint written mid-stream points
+    at page 2 (endCursor of page 1), proving the advance-then-save ordering.
+    """
+    ckpt = tmp_path / "checkpoints" / "current_run.json"
+    page1 = _page([_node("a")], has_next=True, cursor="cursor-after-page1")
+    page2 = _page([_node("b")], has_next=False, cursor="cursor-after-page2")
+
+    saved_cursors = []
+    real_save = fetcher._save_checkpoint
+
+    def _spy_save(started_at, cursor, count):
+        saved_cursors.append(cursor)
+        return real_save(started_at, cursor, count)
+
+    route = respx.post(GRAPHQL_URL)
+    route.side_effect = [httpx.Response(200, json=page1), httpx.Response(200, json=page2)]
+
+    with patch.object(fetcher, "CHECKPOINT_FILE", ckpt):
+        with patch.object(fetcher, "_save_checkpoint", _spy_save):
+            repos, _ = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["a", "b"]
+    # Exactly one checkpoint save happened (after page 1, before page 2),
+    # storing the post-advance cursor.
+    assert saved_cursors == ["cursor-after-page1"]
+
+
+@respx.mock
+async def test_stale_checkpoint_over_24h_is_ignored(tmp_path):
+    """A checkpoint older than 24h is discarded; the run starts cold (after=None)."""
+    ckpt = tmp_path / "checkpoints" / "current_run.json"
+    ckpt.parent.mkdir(parents=True)
+    old = datetime.now(timezone.utc) - timedelta(hours=30)
+    ckpt.write_text(
+        json.dumps(
+            {"started_at": old.isoformat(), "last_cursor": "stale", "repos_processed": 999}
+        )
+    )
+
+    captured = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["after"] = json.loads(request.content)["variables"]["after"]
+        return httpx.Response(200, json=_page([_node("fresh")], has_next=False))
+
+    respx.post(GRAPHQL_URL).mock(side_effect=_handler)
+
+    with patch.object(fetcher, "CHECKPOINT_FILE", ckpt):
+        repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert meta["resumed"] is False
+    assert captured["after"] is None  # cold start, stale cursor not used
+    assert [r.name for r in repos] == ["fresh"]
+
+
+# -- cleanup robustness: a locked checkpoint must not fail a green sync --------
+
+
+@respx.mock
+async def test_locked_checkpoint_at_cleanup_does_not_fail_sync(tmp_path):
+    """A transient PermissionError on the final unlink is swallowed (green stays green).
+
+    Windows briefly share-locks files during AV/indexing; the cleanup unlink is
+    best-effort (a leftover < 24h checkpoint is resumable). A successful fetch
+    must NOT be turned red by a momentary lock on cleanup. We drive TWO pages so
+    a checkpoint is actually written to disk and the cleanup unlink is exercised
+    (a single-page fetch never writes one, so it would not test cleanup at all).
+    """
+    ckpt = tmp_path / "checkpoints" / "current_run.json"
+    route = respx.post(GRAPHQL_URL)
+    route.side_effect = [
+        httpx.Response(200, json=_page([_node("a")], has_next=True, cursor="c2")),
+        httpx.Response(200, json=_page([_node("b")], has_next=False)),
+    ]
+
+    real_unlink = type(ckpt).unlink
+
+    def _locked_unlink(self, *args, **kwargs):
+        # Only the cleanup path targets the checkpoint file; raise there.
+        if str(self) == str(ckpt):
+            raise PermissionError("WinError 32: file is being used by another process")
+        return real_unlink(self, *args, **kwargs)
+
+    with patch.object(fetcher, "CHECKPOINT_FILE", ckpt):
+        with patch.object(type(ckpt), "unlink", _locked_unlink):
+            # Must NOT raise despite the cleanup unlink failing.
+            repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["a", "b"]
+    assert meta["api_calls"] == 2
+    # The checkpoint is intentionally left on disk (resumable) rather than
+    # crashing the run - it will be aged out next run.
+    assert ckpt.exists()
+
+
+@respx.mock
+async def test_missing_checkpoint_at_cleanup_is_silent(tmp_path):
+    """A FileNotFoundError on cleanup (already removed) is swallowed silently."""
+    ckpt = tmp_path / "checkpoints" / "current_run.json"
+    route = respx.post(GRAPHQL_URL)
+    route.side_effect = [
+        httpx.Response(200, json=_page([_node("a")], has_next=True, cursor="c2")),
+        httpx.Response(200, json=_page([_node("b")], has_next=False)),
+    ]
+
+    real_unlink = type(ckpt).unlink
+
+    def _gone_unlink(self, *args, **kwargs):
+        if str(self) == str(ckpt):
+            raise FileNotFoundError("already gone")
+        return real_unlink(self, *args, **kwargs)
+
+    with patch.object(fetcher, "CHECKPOINT_FILE", ckpt):
+        with patch.object(type(ckpt), "unlink", _gone_unlink):
+            repos, _ = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["a", "b"]

--- a/tests/test_fetcher_pagination.py
+++ b/tests/test_fetcher_pagination.py
@@ -1,0 +1,186 @@
+"""Cursor-pagination edge cases for the GraphQL fetcher.
+
+Pagination correctness is what keeps the merge idempotent at scale: the loop
+must stop on hasNextPage=False, advance via endCursor, and never duplicate or
+drop repos across page boundaries. These cover the edges the happy-path tests
+skip: an empty owner, a trailing empty page, a null endCursor on the last page,
+private-repo filtering spread across pages, and the api_calls/cursor accounting.
+
+All traffic is respx-mocked; no network. The autouse isolate_checkpoint fixture
+keeps every checkpoint write under tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import respx
+
+from reporium_db.config import Config
+from reporium_db.fetcher import GRAPHQL_URL, fetch_all_repos
+
+TEST_CONFIG = Config(
+    gh_token="test-token",
+    gh_username="testuser",
+    concurrency_graphql=5,
+    rate_limit_threshold=0.8,
+    checkpoint_interval=1000,
+    nightly_tier_days=30,
+    weekly_tier_days=365,
+)
+
+
+def _page(nodes, has_next, cursor="c1", remaining=4000):
+    return {
+        "data": {
+            "repositoryOwner": {
+                "repositories": {
+                    "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                    "nodes": nodes,
+                }
+            },
+            "rateLimit": {"remaining": remaining, "resetAt": "2026-03-17T06:00:00Z", "cost": 1},
+        }
+    }
+
+
+def _node(name, is_private=False):
+    return {
+        "nameWithOwner": f"testuser/{name}",
+        "name": name,
+        "description": "desc",
+        "stargazerCount": 5,
+        "forkCount": 1,
+        "primaryLanguage": {"name": "Python"},
+        "pushedAt": "2026-03-01T00:00:00Z",
+        "updatedAt": "2026-03-01T00:00:00Z",
+        "createdAt": "2025-01-01T00:00:00Z",
+        "isArchived": False,
+        "isFork": False,
+        "isEmpty": False,
+        "isPrivate": is_private,
+        "parent": None,
+        "repositoryTopics": {"nodes": []},
+        "licenseInfo": {"name": "MIT"},
+        "issues": {"totalCount": 0},
+        "defaultBranchRef": {"name": "main"},
+    }
+
+
+@respx.mock
+async def test_empty_owner_single_empty_page():
+    """An owner with zero repos returns one empty page and no repos."""
+    respx.post(GRAPHQL_URL).mock(
+        return_value=httpx.Response(200, json=_page([], has_next=False, cursor=None))
+    )
+
+    repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert repos == []
+    assert meta["api_calls"] == 1
+    assert meta["resumed"] is False
+
+
+@respx.mock
+async def test_trailing_empty_page_is_consumed():
+    """A non-empty page followed by an empty final page yields only real repos.
+
+    GitHub can report hasNextPage=True then return an empty terminal page; the
+    loop must still terminate cleanly and not invent or drop repos.
+    """
+    route = respx.post(GRAPHQL_URL)
+    route.side_effect = [
+        httpx.Response(200, json=_page([_node("a"), _node("b")], has_next=True, cursor="c2")),
+        httpx.Response(200, json=_page([], has_next=False, cursor="c3")),
+    ]
+
+    repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["a", "b"]
+    assert meta["api_calls"] == 2
+
+
+@respx.mock
+async def test_cursor_threaded_through_each_page():
+    """Each request after the first uses the prior page's endCursor as ``after``."""
+    afters = []
+
+    pages = iter(
+        [
+            _page([_node("a")], has_next=True, cursor="cursor-1"),
+            _page([_node("b")], has_next=True, cursor="cursor-2"),
+            _page([_node("c")], has_next=False, cursor="cursor-3"),
+        ]
+    )
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        afters.append(json.loads(request.content)["variables"]["after"])
+        return httpx.Response(200, json=next(pages))
+
+    respx.post(GRAPHQL_URL).mock(side_effect=_handler)
+
+    repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["a", "b", "c"]
+    # First page starts cold; subsequent pages thread the prior endCursor.
+    assert afters == [None, "cursor-1", "cursor-2"]
+    assert meta["api_calls"] == 3
+
+
+@respx.mock
+async def test_null_end_cursor_on_final_page_does_not_paginate():
+    """hasNextPage=False with a null endCursor terminates after one page."""
+    respx.post(GRAPHQL_URL).mock(
+        return_value=httpx.Response(200, json=_page([_node("only")], has_next=False, cursor=None))
+    )
+
+    repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["only"]
+    assert meta["api_calls"] == 1
+
+
+@respx.mock
+async def test_private_repos_filtered_across_pages():
+    """Private repos are dropped on every page; public ones survive in order."""
+    route = respx.post(GRAPHQL_URL)
+    route.side_effect = [
+        httpx.Response(
+            200,
+            json=_page(
+                [_node("pub1"), _node("secret1", is_private=True)],
+                has_next=True,
+                cursor="c2",
+            ),
+        ),
+        httpx.Response(
+            200,
+            json=_page(
+                [_node("secret2", is_private=True), _node("pub2")],
+                has_next=False,
+            ),
+        ),
+    ]
+
+    repos, _ = await fetch_all_repos(TEST_CONFIG)
+
+    names = [r.name for r in repos]
+    assert names == ["pub1", "pub2"]
+    assert "secret1" not in names and "secret2" not in names
+
+
+@respx.mock
+async def test_all_private_page_yields_no_repos_but_counts_call():
+    """A page of only private repos contributes zero repos but still counts the call."""
+    respx.post(GRAPHQL_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=_page([_node("p", is_private=True)], has_next=False),
+        )
+    )
+
+    repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert repos == []
+    assert meta["api_calls"] == 1

--- a/tests/test_partitioner_contract.py
+++ b/tests/test_partitioner_contract.py
@@ -1,0 +1,176 @@
+"""Schema / contract tests for partitioned output.
+
+Four downstream services read this directory verbatim (reporium-api,
+reporium-ingestion, reporium-dataset, reporium-metrics). These tests pin the
+*contract* - the exact keys and value types those consumers rely on - so a
+field rename or a dropped key in partitioner/models trips a test instead of
+silently breaking a consumer in production. They use offline fixtures only
+(make_repo + tmp_path); no network, no live data artifacts.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from datetime import datetime, timezone
+
+from reporium_db.models import RepoMetadata
+from reporium_db.partitioner import write_partitioned
+from tests.conftest import make_repo
+
+# The full field set every emitted repo dict must carry. Locked here so that
+# adding/removing a RepoMetadata field is a deliberate, test-visible change.
+EXPECTED_REPO_FIELDS = {
+    "nameWithOwner",
+    "name",
+    "description",
+    "stars",
+    "forks",
+    "primaryLanguage",
+    "pushedAt",
+    "updatedAt",
+    "createdAt",
+    "isArchived",
+    "isFork",
+    "isEmpty",
+    "topics",
+    "licenseName",
+    "openIssues",
+    "defaultBranch",
+    "parentRepo",
+    "parentStars",
+    "parentForks",
+    "isPrivate",
+}
+
+
+def test_repo_field_set_matches_model():
+    """The expected field set tracks the RepoMetadata dataclass exactly.
+
+    Guards the assertion below from going stale: if a field is added to the
+    model without updating EXPECTED_REPO_FIELDS, this fails first and tells the
+    author to update the contract intentionally.
+    """
+    model_fields = {f.name for f in dataclasses.fields(RepoMetadata)}
+    assert model_fields == EXPECTED_REPO_FIELDS
+
+
+# -- index.json contract -------------------------------------------------------
+
+
+def test_index_top_level_keys(tmp_path):
+    """index.json has exactly the meta/categories/languages top-level keys."""
+    index = write_partitioned([make_repo("a")], tmp_path)
+    assert set(index.keys()) == {"meta", "categories", "languages"}
+
+
+def test_index_meta_contract(tmp_path):
+    """meta carries total (int), version (str), and an ISO-8601 last_updated."""
+    write_partitioned([make_repo("a"), make_repo("b")], tmp_path)
+    index = json.loads((tmp_path / "index.json").read_text())
+
+    meta = index["meta"]
+    assert set(meta.keys()) == {"total", "last_updated", "version"}
+    assert meta["total"] == 2
+    assert isinstance(meta["total"], int)
+    assert meta["version"] == "1.0.0"
+    # last_updated must round-trip through datetime.fromisoformat.
+    parsed = datetime.fromisoformat(meta["last_updated"])
+    assert parsed.tzinfo is not None  # timezone-aware (UTC)
+
+
+def test_index_category_and_language_counts_are_ints(tmp_path):
+    """categories/languages map names to positive int counts, sorted descending."""
+    repos = [
+        make_repo("a", language="Python", topics=["llm", "rag"]),
+        make_repo("b", language="Python", topics=["llm"]),
+        make_repo("c", language="Go", topics=["rag"]),
+    ]
+    index = write_partitioned(repos, tmp_path)
+
+    assert index["languages"] == {"Python": 2, "Go": 1}
+    assert index["categories"]["llm"] == 2
+    assert index["categories"]["rag"] == 2
+    for v in list(index["languages"].values()) + list(index["categories"].values()):
+        assert isinstance(v, int) and v > 0
+    # Languages are sorted by descending count (Python before Go).
+    assert list(index["languages"].keys())[0] == "Python"
+
+
+# -- per-repo record contract across every output file -------------------------
+
+
+def _all_repo_records(data_dir):
+    """Yield every repo dict written to recent/top_starred/by_*/full."""
+    files = [
+        data_dir / "recent.json",
+        data_dir / "top_starred.json",
+    ]
+    files += list((data_dir / "by_category").glob("*.json"))
+    files += list((data_dir / "by_language").glob("*.json"))
+    files += list((data_dir / "full").glob("*.json"))
+    for f in files:
+        for rec in json.loads(f.read_text()):
+            yield f.name, rec
+
+
+def test_every_emitted_record_has_full_field_set(tmp_path):
+    """Every repo dict in every partition file carries the full model field set."""
+    recent_date = (datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    repos = [
+        make_repo("a", language="Python", topics=["llm"], pushed_at=recent_date),
+        make_repo("b", language="Go", topics=["rag"], pushed_at=recent_date),
+    ]
+    write_partitioned(repos, tmp_path)
+
+    seen_any = False
+    for fname, rec in _all_repo_records(tmp_path):
+        seen_any = True
+        assert set(rec.keys()) == EXPECTED_REPO_FIELDS, f"field drift in {fname}"
+    assert seen_any, "no repo records were emitted"
+
+
+def test_full_partition_is_lossless_round_trip(tmp_path):
+    """The full/ partition reconstructs RepoMetadata objects equal to the input."""
+    recent_date = (datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    original = [
+        make_repo("a", stars=42, language="Python", topics=["llm", "rag"], pushed_at=recent_date),
+        make_repo("b", stars=7, language="Rust", topics=[], pushed_at=recent_date),
+    ]
+    write_partitioned(original, tmp_path)
+
+    part = json.loads((tmp_path / "full" / "repos_0000.json").read_text())
+    reconstructed = [RepoMetadata(**rec) for rec in part]
+
+    assert reconstructed == original
+
+
+def test_output_is_valid_utf8_json(tmp_path):
+    """All written files parse as JSON (atomic .tmp files are never left behind)."""
+    write_partitioned([make_repo("a", topics=["ml"])], tmp_path)
+    for f in tmp_path.rglob("*.json"):
+        json.loads(f.read_text())  # raises if malformed
+    assert list(tmp_path.rglob("*.tmp")) == []
+
+
+# -- filename-sanitisation contract (path safety for consumers) ----------------
+
+
+def test_category_filename_sanitised(tmp_path):
+    """Topics with slashes/spaces are written to filesystem-safe filenames."""
+    write_partitioned([make_repo("a", topics=["machine learning", "a/b"])], tmp_path)
+
+    cat_dir = tmp_path / "by_category"
+    assert (cat_dir / "machine_learning.json").exists()
+    assert (cat_dir / "a_b.json").exists()
+    # No path traversal / nested dirs created from the slash.
+    assert not (cat_dir / "a").exists()
+
+
+def test_language_unknown_bucket(tmp_path):
+    """Repos with no primaryLanguage land in by_language/unknown.json."""
+    repo = make_repo("a", language="Python")
+    repo.primaryLanguage = None
+    write_partitioned([repo], tmp_path)
+
+    assert (tmp_path / "by_language" / "unknown.json").exists()

--- a/tests/test_scheduler_boundaries.py
+++ b/tests/test_scheduler_boundaries.py
@@ -1,0 +1,118 @@
+"""Tier-boundary and threshold-edge tests for the scheduler.
+
+The existing tests cover the happy path (clearly nightly / weekly / monthly).
+These pin the EXACT boundaries that the get_tier(... <= nightly_days) and
+(... <= weekly_days) comparisons hinge on, plus custom thresholds and a few
+edge inputs (future push dates, naive timestamps, the Z-suffix path). Getting a
+boundary off by one silently mis-tiers thousands of repos at 100K scale, so each
+boundary is asserted on both sides.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from reporium_db.scheduler import (
+    TIER_MONTHLY,
+    TIER_NIGHTLY,
+    TIER_WEEKLY,
+    get_tier,
+)
+
+
+def _pushed_days_ago(days: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+# -- nightly/weekly boundary (default thresholds 30 / 365) ---------------------
+
+
+def test_tier_exactly_at_nightly_boundary_is_nightly():
+    """age_days == nightly_days (30) is INCLUSIVE of nightly (uses <=).
+
+    ``.days`` floors, so pushing slightly MORE than 30 days ago (30d + 1h)
+    yields exactly age_days == 30 - the boundary value. With ``<=`` this is
+    nightly; flipping to ``<`` would mis-tier it as weekly (the mutation this
+    test exists to catch).
+    """
+    pushed = (datetime.now(timezone.utc) - timedelta(days=30, hours=1)).isoformat()
+    assert get_tier(pushed) == TIER_NIGHTLY
+
+
+def test_tier_just_past_nightly_boundary_is_weekly():
+    """age_days == nightly_days + 1 (31) crosses into weekly."""
+    pushed = (datetime.now(timezone.utc) - timedelta(days=31, hours=1)).isoformat()
+    assert get_tier(pushed) == TIER_WEEKLY
+
+
+def test_tier_exactly_at_weekly_boundary_is_weekly():
+    """age_days == weekly_days (365) is INCLUSIVE of weekly (uses <=)."""
+    pushed = (datetime.now(timezone.utc) - timedelta(days=365, hours=1)).isoformat()
+    assert get_tier(pushed) == TIER_WEEKLY
+
+
+def test_tier_just_past_weekly_boundary_is_monthly():
+    """age_days == weekly_days + 1 (366) crosses into monthly."""
+    pushed = (datetime.now(timezone.utc) - timedelta(days=366, hours=1)).isoformat()
+    assert get_tier(pushed) == TIER_MONTHLY
+
+
+# -- custom thresholds are honored ---------------------------------------------
+
+
+def test_tier_custom_nightly_threshold():
+    """A repo 10 days old is weekly when nightly_days is tightened to 7."""
+    pushed = _pushed_days_ago(10)
+    assert get_tier(pushed, nightly_days=7, weekly_days=365) == TIER_WEEKLY
+
+
+def test_tier_custom_weekly_threshold():
+    """A repo 100 days old is monthly when weekly_days is tightened to 90."""
+    pushed = _pushed_days_ago(100)
+    assert get_tier(pushed, nightly_days=30, weekly_days=90) == TIER_MONTHLY
+
+
+@pytest.mark.parametrize(
+    "age_days,nightly,weekly,expected",
+    [
+        (0, 30, 365, TIER_NIGHTLY),       # pushed today
+        (29, 30, 365, TIER_NIGHTLY),
+        (31, 30, 365, TIER_WEEKLY),
+        (200, 30, 365, TIER_WEEKLY),
+        (400, 30, 365, TIER_MONTHLY),
+        (5, 1, 7, TIER_WEEKLY),           # custom tight thresholds
+        (10, 1, 7, TIER_MONTHLY),
+    ],
+)
+def test_tier_table(age_days, nightly, weekly, expected):
+    """Table-driven coverage across both boundaries and custom thresholds."""
+    # Add an hour of slack so integer-day flooring lands deterministically.
+    pushed = (datetime.now(timezone.utc) - timedelta(days=age_days, hours=1)).isoformat()
+    assert get_tier(pushed, nightly_days=nightly, weekly_days=weekly) == expected
+
+
+# -- edge inputs ---------------------------------------------------------------
+
+
+def test_tier_future_push_date_is_nightly():
+    """A repo with a future pushedAt (clock skew) has negative age => nightly.
+
+    This documents the current behavior so a future regression that flips skewed
+    timestamps to monthly (and starves a freshly pushed repo of nightly checks)
+    is caught.
+    """
+    future = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+    assert get_tier(future) == TIER_NIGHTLY
+
+
+def test_tier_z_suffix_at_boundary():
+    """The Z-suffix parse path respects the nightly boundary like the +00:00 path."""
+    pushed = (datetime.now(timezone.utc) - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert get_tier(pushed) == TIER_NIGHTLY
+
+
+def test_tier_empty_string_defaults_monthly():
+    """An empty pushedAt string is falsy and defaults to monthly (no crash)."""
+    assert get_tier("") == TIER_MONTHLY


### PR DESCRIPTION
## Summary

Adds **37 offline tests** (mocked GraphQL via `respx`; no network, keys, or cloud) and fixes a real Windows robustness bug surfaced while writing them. Full suite goes from 73 tests (1 Windows flake) to **110 passing, deterministic**.

## Bug fix (production code)

`fetch_all_repos` ended a successful fetch with an **unguarded** `CHECKPOINT_FILE.unlink()`. On Windows a momentary share lock (antivirus / indexing / a concurrent reader) makes `unlink` raise `PermissionError [WinError 5/32]`, turning a fully successful sync **RED**. This was reproducible: `test_fetch_two_pages` flaked red in the full suite on Windows (`os.replace` / `unlink` `PermissionError`).

Replaced with a best-effort `_clear_checkpoint()` that swallows:
- `FileNotFoundError` (already removed / never written for a single-page fetch),
- `OSError` (momentarily locked) -> logs a warning and continues.

This is safe because a leftover checkpoint is `< 24h` old and resumable, and resume is idempotent (the cursor is saved *after* it advances, so the next run fetches the **next** page, never re-counting). It is aged out on the next run by the existing 24h staleness check.

## Test isolation

Added an autouse `isolate_checkpoint` fixture (conftest) pinning `CHECKPOINT_FILE` under `tmp_path`. Multi-page fetcher tests previously wrote a **real** `checkpoints/current_run.json` into the repo working tree (a data artifact that must never be committed) and collided with each other on Windows. The suite is now hermetic on every OS.

## New tests

- **`test_fetcher_checkpoint.py` (6)** - checkpoint-cache resilience: a sustained 502 raises but **leaves a resumable checkpoint** for the next run; resume **starts at the saved cursor with no double-count** (idempotent merge); checkpoint stores the post-advance cursor; stale (`>24h`) checkpoint ignored (cold start); locked / missing checkpoint at cleanup does **not** fail a green sync.
- **`test_fetcher_pagination.py` (6)** - cursor-pagination edges: empty owner, trailing empty page, cursor threaded across pages (`after` = prior `endCursor`), null `endCursor`, private-repo filtering spread across pages.
- **`test_scheduler_boundaries.py` (16)** - exact nightly/weekly tier boundaries asserted on **both sides**, custom thresholds, table-driven cases, edge inputs (future push date, Z-suffix, empty string).
- **`test_partitioner_contract.py` (9)** - the schema/contract the four downstream consumers (reporium-api, reporium-ingestion, reporium-dataset, reporium-metrics) read: `index.json` shape, full `RepoMetadata` field set on **every** emitted record, lossless `full/` round-trip, valid JSON / no `.tmp` leftovers, filename sanitisation.

## Validation (local; CI is offline so this is the only validation)

```
$ python -m pytest -q
......................................................................
......................................................................
110 passed in 5.09s

$ ruff check reporium_db/ tests/
All checks passed!
```

Run twice -> deterministic 110 passed. No stray `checkpoints/` or `snapshot/` left in the tree.

**Mutation-checked** (each turns the relevant new tests red, confirming real assertions):
- revert the cleanup guard to unguarded `unlink` -> cleanup-robustness tests fail
- save checkpoint *before* advancing the cursor -> post-advance-cursor test fails (`[None, ...]`)
- `get_tier` `<=` -> `<` on either boundary -> the exact-boundary tests fail
- rename a `RepoMetadata` field -> partition contract tests fail

## Scope / safety

ASCII only. No live infra touched (all GraphQL mocked). No security/HITL/privacy weakening - the private-repo filter is exercised, not relaxed. No data/snapshot/checkpoint artifacts or `uv.lock` committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
