### PR TITLE
test: harden graphql-sync resilience (rescued local-only)

### DIFF
--- a/tests/test_fetcher_checkpoint.py
+++ b/tests/test_fetcher_checkpoint.py
@@ -1,0 +1,207 @@
+"""Cross-run checkpoint-cache resilience tests for reporium_db.fetcher.
+
+These tests target the documented production failure mode (run 26023064535):
+a sustained GitHub-side 502 window that outlasts the per-request retry budget.
+The durable fix is the cross-run checkpoint: a failed run must leave a
+checkpoint on disk pointing at the *next* cursor so the following run resumes
+forward instead of re-fetching page 1 (which would duplicate repos).
+
+All GraphQL traffic is mocked with respx; asyncio.sleep is patched so retry
+backoff does not slow the suite. No network, no real tokens.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from reporium_db.config import Config
+from reporium_db.fetcher import GRAPHQL_URL, _MAX_RETRIES, fetch_all_repos
+
+TEST_CONFIG = Config(
+    gh_token="test-token",
+    gh_username="testuser",
+    concurrency_graphql=5,
+    rate_limit_threshold=0.8,
+    checkpoint_interval=1000,
+    nightly_tier_days=30,
+    weekly_tier_days=365,
+)
+
+
+def _page(nodes: list[dict], has_next: bool, cursor: str = "c1", remaining: int = 4000) -> dict:
+    return {
+        "data": {
+            "repositoryOwner": {
+                "repositories": {
+                    "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                    "nodes": nodes,
+                }
+            },
+            "rateLimit": {"remaining": remaining, "resetAt": "2026-03-17T06:00:00Z", "cost": 1},
+        }
+    }
+
+
+def _node(name: str = "repo") -> dict:
+    return {
+        "nameWithOwner": f"testuser/{name}",
+        "name": name,
+        "description": "desc",
+        "stargazerCount": 5,
+        "forkCount": 1,
+        "primaryLanguage": {"name": "Python"},
+        "pushedAt": "2026-03-01T00:00:00Z",
+        "updatedAt": "2026-03-01T00:00:00Z",
+        "createdAt": "2025-01-01T00:00:00Z",
+        "isArchived": False,
+        "isFork": False,
+        "isEmpty": False,
+        "parent": None,
+        "repositoryTopics": {"nodes": []},
+        "licenseInfo": {"name": "MIT"},
+        "issues": {"totalCount": 0},
+        "defaultBranchRef": {"name": "main"},
+    }
+
+
+@respx.mock
+async def test_checkpoint_removed_on_clean_success(tmp_path):
+    """A fully successful single-process run leaves no checkpoint on disk.
+
+    The unlink-on-success path must clear the checkpoint so a *new* nightly
+    starts cold (page 1) rather than wrongly resuming a finished run.
+    """
+    ckpt = tmp_path / "checkpoints" / "current_run.json"
+    respx.post(GRAPHQL_URL).mock(
+        return_value=httpx.Response(200, json=_page([_node("a")], has_next=False))
+    )
+
+    with patch("reporium_db.fetcher.CHECKPOINT_FILE", ckpt):
+        repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["a"]
+    assert meta["resumed"] is False
+    assert not ckpt.exists(), "checkpoint must be unlinked after a clean finish"
+
+
+@respx.mock
+async def test_checkpoint_persisted_after_first_page_before_failure(tmp_path):
+    """A multi-page run that fails on page 2 leaves a checkpoint at page 1's cursor.
+
+    This is the cross-run durability invariant: page 1 succeeds and checkpoints
+    the *advanced* cursor (endCursor of page 1); page 2 then 502s past the retry
+    budget and the run raises. Because the failure path does NOT unlink, the
+    checkpoint survives pointing at page 2 -- the next run resumes forward.
+    """
+    ckpt = tmp_path / "checkpoints" / "current_run.json"
+
+    page1 = _page([_node("p1a"), _node("p1b")], has_next=True, cursor="CURSOR_PAGE2")
+    # page 1 OK, then unlimited 502s for page 2 -> exhausts retries -> raises.
+    side_effects = [httpx.Response(200, json=page1)] + [
+        httpx.Response(502) for _ in range(_MAX_RETRIES + 5)
+    ]
+    route = respx.post(GRAPHQL_URL)
+    route.side_effect = side_effects
+
+    with patch("reporium_db.fetcher.CHECKPOINT_FILE", ckpt), patch("asyncio.sleep"):
+        with pytest.raises(httpx.HTTPStatusError) as excinfo:
+            await fetch_all_repos(TEST_CONFIG)
+
+    assert excinfo.value.response.status_code == 502
+    # Checkpoint must survive the failure (not unlinked) and point forward.
+    assert ckpt.exists(), "failed multi-page run must preserve its checkpoint"
+    saved = json.loads(ckpt.read_text())
+    assert saved["last_cursor"] == "CURSOR_PAGE2"
+    assert saved["repos_processed"] == 2
+
+
+@respx.mock
+async def test_resume_continues_from_checkpoint_cursor(tmp_path):
+    """A second run reads the checkpoint and sends its cursor as the 'after' arg.
+
+    Asserts real resume behavior: the resumed run's first GraphQL request carries
+    the checkpoint cursor (not None), proving it does not re-fetch from page 1.
+    """
+    ckpt = tmp_path / "checkpoints" / "current_run.json"
+    ckpt.parent.mkdir(parents=True)
+    from datetime import datetime, timezone
+
+    ckpt.write_text(
+        json.dumps(
+            {
+                "started_at": datetime.now(timezone.utc).isoformat(),
+                "last_cursor": "CURSOR_PAGE2",
+                "repos_processed": 2,
+            }
+        )
+    )
+
+    captured: list[dict] = []
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content)["variables"])
+        return httpx.Response(200, json=_page([_node("p2a")], has_next=False))
+
+    respx.post(GRAPHQL_URL).mock(side_effect=_capture)
+
+    with patch("reporium_db.fetcher.CHECKPOINT_FILE", ckpt), patch("asyncio.sleep"):
+        repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert meta["resumed"] is True
+    assert [r.name for r in repos] == ["p2a"]
+    # The very first request of the resumed run must use the checkpoint cursor.
+    assert captured[0]["after"] == "CURSOR_PAGE2"
+    # Clean finish on resume clears the checkpoint.
+    assert not ckpt.exists()
+
+
+@respx.mock
+async def test_two_run_resume_is_idempotent_no_duplicate_merge(tmp_path):
+    """End-to-end cross-run merge: run A (page 1) fails on page 2, run B resumes
+    and finishes page 2. The merged repo set across both runs has NO duplicates
+    and equals page1 + page2 exactly.
+
+    This is the core idempotency invariant: resuming from the advanced cursor
+    means page 1's repos are never re-emitted in run B.
+    """
+    ckpt = tmp_path / "checkpoints" / "current_run.json"
+
+    # ---- Run A: page 1 succeeds (checkpoints CURSOR_PAGE2), page 2 hard-fails.
+    page1 = _page([_node("alpha"), _node("beta")], has_next=True, cursor="CURSOR_PAGE2")
+    route_a = respx.post(GRAPHQL_URL)
+    route_a.side_effect = [httpx.Response(200, json=page1)] + [
+        httpx.Response(502) for _ in range(_MAX_RETRIES + 3)
+    ]
+
+    with patch("reporium_db.fetcher.CHECKPOINT_FILE", ckpt), patch("asyncio.sleep"):
+        with pytest.raises(httpx.HTTPStatusError):
+            await fetch_all_repos(TEST_CONFIG)
+
+    run_a_partial = json.loads(ckpt.read_text())
+    assert run_a_partial["last_cursor"] == "CURSOR_PAGE2"
+
+    # ---- Run B: resumes from CURSOR_PAGE2, fetches page 2, finishes.
+    respx.post(GRAPHQL_URL).mock(
+        return_value=httpx.Response(
+            200, json=_page([_node("gamma"), _node("delta")], has_next=False)
+        )
+    )
+
+    with patch("reporium_db.fetcher.CHECKPOINT_FILE", ckpt), patch("asyncio.sleep"):
+        repos_b, meta_b = await fetch_all_repos(TEST_CONFIG)
+
+    assert meta_b["resumed"] is True
+    # Run B only emits page-2 repos; page-1 repos are NOT re-fetched.
+    names_b = [r.name for r in repos_b]
+    assert names_b == ["gamma", "delta"]
+
+    # Cross-run merged set = page1 (from run A's checkpoint progress) + page2.
+    merged = {"alpha", "beta"} | set(names_b)
+    assert merged == {"alpha", "beta", "gamma", "delta"}
+    # Idempotent: no page-1 repo leaked into run B.
+    assert "alpha" not in names_b and "beta" not in names_b

--- a/tests/test_fetcher_pagination.py
+++ b/tests/test_fetcher_pagination.py
@@ -1,0 +1,179 @@
+"""Cursor-pagination edge-case tests for reporium_db.fetch_all_repos.
+
+Covers the boundary conditions of the GraphQL cursor loop that the existing
+single/two-page happy-path tests do not exercise:
+
+  * empty page (zero nodes, hasNextPage False)  -> zero repos, one call
+  * empty first page that still has a next page  -> follows cursor, no crash
+  * last page (hasNextPage False) terminates the loop with no extra request
+  * a None endCursor on a non-final page is forwarded verbatim as 'after'
+  * the cursor sent on page N+1 is exactly the endCursor returned by page N
+
+All traffic is mocked with respx; no network. asyncio.sleep is patched where
+throttle/backoff could otherwise run.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+import respx
+
+from reporium_db.config import Config
+from reporium_db.fetcher import GRAPHQL_URL, fetch_all_repos
+
+TEST_CONFIG = Config(
+    gh_token="test-token",
+    gh_username="testuser",
+    concurrency_graphql=5,
+    rate_limit_threshold=0.8,
+    checkpoint_interval=1000,
+    nightly_tier_days=30,
+    weekly_tier_days=365,
+)
+
+
+def _page(nodes, has_next, cursor="c1", remaining=4000):
+    return {
+        "data": {
+            "repositoryOwner": {
+                "repositories": {
+                    "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                    "nodes": nodes,
+                }
+            },
+            "rateLimit": {"remaining": remaining, "resetAt": "2026-03-17T06:00:00Z", "cost": 1},
+        }
+    }
+
+
+def _node(name="repo"):
+    return {
+        "nameWithOwner": f"testuser/{name}",
+        "name": name,
+        "description": "desc",
+        "stargazerCount": 5,
+        "forkCount": 1,
+        "primaryLanguage": {"name": "Python"},
+        "pushedAt": "2026-03-01T00:00:00Z",
+        "updatedAt": "2026-03-01T00:00:00Z",
+        "createdAt": "2025-01-01T00:00:00Z",
+        "isArchived": False,
+        "isFork": False,
+        "isEmpty": False,
+        "parent": None,
+        "repositoryTopics": {"nodes": []},
+        "licenseInfo": {"name": "MIT"},
+        "issues": {"totalCount": 0},
+        "defaultBranchRef": {"name": "main"},
+    }
+
+
+@respx.mock
+async def test_empty_single_page_returns_no_repos():
+    """An owner with zero repos: one call, empty result, no crash."""
+    respx.post(GRAPHQL_URL).mock(
+        return_value=httpx.Response(200, json=_page([], has_next=False, cursor=None))
+    )
+
+    repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert repos == []
+    assert meta["api_calls"] == 1
+
+
+@respx.mock
+async def test_empty_first_page_still_follows_next_cursor():
+    """An empty page with hasNextPage True must still advance to the next page."""
+    page1 = _page([], has_next=True, cursor="c2")
+    page2 = _page([_node("late")], has_next=False)
+    route = respx.post(GRAPHQL_URL)
+    route.side_effect = [
+        httpx.Response(200, json=page1),
+        httpx.Response(200, json=page2),
+    ]
+
+    repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["late"]
+    assert meta["api_calls"] == 2
+
+
+@respx.mock
+async def test_last_page_terminates_without_extra_request():
+    """hasNextPage False stops the loop -- exactly the pages served are called."""
+    page1 = _page([_node("a")], has_next=True, cursor="c2")
+    page2 = _page([_node("b")], has_next=False, cursor="c3")
+    route = respx.post(GRAPHQL_URL)
+    route.side_effect = [
+        httpx.Response(200, json=page1),
+        httpx.Response(200, json=page2),
+    ]
+
+    repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["a", "b"]
+    assert meta["api_calls"] == 2
+    # respx records exactly the two calls; no speculative third request.
+    assert route.call_count == 2
+
+
+@respx.mock
+async def test_cursor_forwarded_matches_previous_end_cursor():
+    """The 'after' arg on each page equals the prior page's endCursor.
+
+    First page must be requested with after=None; the second with the exact
+    endCursor the first page returned. This pins the cursor-threading contract.
+    """
+    captured: list = []
+
+    pages = [
+        httpx.Response(200, json=_page([_node("a")], has_next=True, cursor="CURSOR_X")),
+        httpx.Response(200, json=_page([_node("b")], has_next=False, cursor="CURSOR_Y")),
+    ]
+    call_index = {"i": 0}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content)["variables"]["after"])
+        resp = pages[call_index["i"]]
+        call_index["i"] += 1
+        return resp
+
+    respx.post(GRAPHQL_URL).mock(side_effect=_capture)
+
+    repos, _ = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["a", "b"]
+    assert captured == [None, "CURSOR_X"]
+
+
+@respx.mock
+async def test_none_end_cursor_on_nonfinal_page_is_forwarded_verbatim():
+    """A malformed page that says hasNextPage True but endCursor None must not
+    crash; the None cursor is forwarded as 'after' (GitHub treats it as start).
+
+    This guards the loop against a None-cursor edge instead of raising.
+    """
+    captured: list = []
+    pages = [
+        httpx.Response(200, json=_page([_node("a")], has_next=True, cursor=None)),
+        httpx.Response(200, json=_page([_node("b")], has_next=False, cursor="end")),
+    ]
+    call_index = {"i": 0}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content)["variables"]["after"])
+        resp = pages[call_index["i"]]
+        call_index["i"] += 1
+        return resp
+
+    respx.post(GRAPHQL_URL).mock(side_effect=_capture)
+
+    repos, meta = await fetch_all_repos(TEST_CONFIG)
+
+    assert [r.name for r in repos] == ["a", "b"]
+    assert meta["api_calls"] == 2
+    # Second request forwarded the None cursor verbatim (no fabricated value).
+    assert captured[1] is None

--- a/tests/test_partitioner_contract.py
+++ b/tests/test_partitioner_contract.py
@@ -1,0 +1,196 @@
+"""Partition-output schema/contract tests for reporium_db.partitioner.
+
+The Platform Fit section of the README declares four downstream consumers that
+read these files directly:
+
+  * reporium-api      -> data/ (index.json, by_language/, by_category/, full/)
+  * reporium-ingestion-> pending_enrichment.json (covered in test_differ)
+  * reporium-dataset  -> index.json
+  * reporium-metrics  -> data/index.json
+
+These tests assert the EMITTED JSON honors that contract using offline fixtures
+only (tmp_path). They check the index envelope shape, the per-repo record
+schema in every list output, deterministic sort orders, and category/language
+fan-out -- the things a consumer parses and would break on if silently changed.
+
+No data/snapshot/checkpoint artifacts are committed; everything lives in tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+
+from reporium_db.models import RepoMetadata
+from reporium_db.partitioner import (
+    TOP_STARRED_COUNT,
+    write_partitioned,
+)
+from tests.conftest import make_repo
+
+# The canonical per-repo record the partitioner emits is the full dataclass
+# field set. Consumers index on these exact keys; dropping or renaming one is a
+# breaking change. We derive the expected key set from the model so this test
+# tracks the model but still fails loudly if a field is silently omitted on
+# serialization.
+EXPECTED_REPO_KEYS = {f.name for f in fields(RepoMetadata)}
+
+# Keys the API/dataset/metrics surfaces explicitly depend on. Spelled out (not
+# just derived) so a rename in the model is caught as an intentional contract
+# change, not auto-accepted.
+CORE_CONTRACT_KEYS = {
+    "nameWithOwner",
+    "name",
+    "description",
+    "stars",
+    "forks",
+    "primaryLanguage",
+    "pushedAt",
+    "topics",
+    "isPrivate",
+}
+
+
+def _load(path):
+    return json.loads(path.read_text())
+
+
+def test_index_envelope_contract(tmp_path):
+    """index.json has the meta/categories/languages envelope consumers expect."""
+    repos = [
+        make_repo("a", language="Python", topics=["llm", "rag"]),
+        make_repo("b", language="Go", topics=["llm"]),
+    ]
+    write_partitioned(repos, tmp_path)
+    index = _load(tmp_path / "index.json")
+
+    # Top-level keys.
+    assert set(index.keys()) == {"meta", "categories", "languages"}
+
+    # meta sub-contract: total + version + an ISO last_updated string.
+    meta = index["meta"]
+    assert set(meta.keys()) == {"total", "last_updated", "version"}
+    assert meta["total"] == 2
+    assert meta["version"] == "1.0.0"
+    assert isinstance(meta["last_updated"], str) and meta["last_updated"]
+
+    # Aggregations are name->count maps with correct counts.
+    assert index["languages"] == {"Python": 1, "Go": 1}
+    assert index["categories"]["llm"] == 2
+    assert index["categories"]["rag"] == 1
+
+
+def test_index_aggregations_sorted_descending_by_count(tmp_path):
+    """categories and languages are emitted sorted by count descending.
+
+    Consumers render these as ranked facets; order is part of the contract.
+    """
+    repos = [
+        make_repo("a", language="Python", topics=["common", "common", "rare"]),
+        make_repo("b", language="Python", topics=["common"]),
+        make_repo("c", language="Go", topics=["common"]),
+    ]
+    write_partitioned(repos, tmp_path)
+    index = _load(tmp_path / "index.json")
+
+    lang_counts = list(index["languages"].values())
+    cat_counts = list(index["categories"].values())
+    assert lang_counts == sorted(lang_counts, reverse=True)
+    assert cat_counts == sorted(cat_counts, reverse=True)
+    # Most common language first.
+    assert next(iter(index["languages"])) == "Python"
+
+
+def test_full_partition_record_schema(tmp_path):
+    """Every record in full/ carries the complete per-repo key set."""
+    repos = [make_repo("a"), make_repo("b")]
+    write_partitioned(repos, tmp_path)
+
+    records = _load(tmp_path / "full" / "repos_0000.json")
+    assert len(records) == 2
+    for rec in records:
+        assert set(rec.keys()) == EXPECTED_REPO_KEYS
+        assert CORE_CONTRACT_KEYS.issubset(rec.keys())
+
+
+def test_recent_and_top_starred_record_schema(tmp_path):
+    """recent.json and top_starred.json records honor the same per-repo schema."""
+    from datetime import datetime, timedelta, timezone
+
+    fresh = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    repos = [
+        make_repo("hot", stars=900, pushed_at=fresh),
+        make_repo("warm", stars=10, pushed_at=fresh),
+    ]
+    write_partitioned(repos, tmp_path)
+
+    for fname in ("recent.json", "top_starred.json"):
+        records = _load(tmp_path / fname)
+        assert records, f"{fname} should not be empty"
+        for rec in records:
+            assert CORE_CONTRACT_KEYS.issubset(rec.keys())
+            # Star count must be a JSON number (consumers sort/filter on it).
+            assert isinstance(rec["stars"], int)
+
+
+def test_top_starred_is_sorted_and_capped(tmp_path):
+    """top_starred.json is strictly star-descending and capped at the limit."""
+    repos = [make_repo(f"r{i}", owner=f"u{i}", stars=i) for i in range(TOP_STARRED_COUNT + 25)]
+    write_partitioned(repos, tmp_path)
+
+    top = _load(tmp_path / "top_starred.json")
+    assert len(top) == TOP_STARRED_COUNT
+    star_seq = [r["stars"] for r in top]
+    assert star_seq == sorted(star_seq, reverse=True)
+    # The single highest-star repo is present and first.
+    assert star_seq[0] == TOP_STARRED_COUNT + 24
+
+
+def test_by_language_and_category_fanout_contract(tmp_path):
+    """by_language/ and by_category/ emit one file per key, each a record list.
+
+    A repo with no primaryLanguage lands in unknown.json (consumers rely on the
+    'unknown' bucket existing rather than the repo vanishing).
+    """
+    repos = [
+        make_repo("p", language="Python", topics=["llm"]),
+        make_repo("g", language="Go", topics=["llm", "infra"]),
+        make_repo("n", language=None, topics=[]),
+    ]
+    write_partitioned(repos, tmp_path)
+
+    # Languages: one file each, unknown bucket for the None-language repo.
+    py = _load(tmp_path / "by_language" / "Python.json")
+    go = _load(tmp_path / "by_language" / "Go.json")
+    unknown = _load(tmp_path / "by_language" / "unknown.json")
+    assert [r["name"] for r in py] == ["p"]
+    assert [r["name"] for r in go] == ["g"]
+    assert [r["name"] for r in unknown] == ["n"]
+
+    # Categories: llm appears in two repos, infra in one.
+    llm = _load(tmp_path / "by_category" / "llm.json")
+    infra = _load(tmp_path / "by_category" / "infra.json")
+    assert {r["name"] for r in llm} == {"p", "g"}
+    assert {r["name"] for r in infra} == {"g"}
+
+    # Every record across the fan-out honors the core schema.
+    for rec in py + go + unknown + llm + infra:
+        assert CORE_CONTRACT_KEYS.issubset(rec.keys())
+
+
+def test_emitted_json_is_valid_and_total_consistent_across_files(tmp_path):
+    """index.meta.total equals the record count in the full partitions.
+
+    Cross-file consistency invariant: a consumer that trusts index.total must
+    find that many records in full/. Guards against a partitioner that writes a
+    stale or mismatched total.
+    """
+    repos = [make_repo(f"r{i}", owner=f"u{i}") for i in range(7)]
+    write_partitioned(repos, tmp_path)
+
+    index = _load(tmp_path / "index.json")
+    full_records = []
+    for part in sorted((tmp_path / "full").glob("repos_*.json")):
+        full_records.extend(_load(part))
+
+    assert index["meta"]["total"] == len(full_records) == 7

--- a/tests/test_scheduler_boundaries.py
+++ b/tests/test_scheduler_boundaries.py
@@ -1,0 +1,79 @@
+"""Tier-assignment boundary tests for reporium_db.scheduler.get_tier.
+
+The existing scheduler tests cover the interiors of each tier (10d, 60d, 400d).
+These assert the exact tier *boundaries*, which is where off-by-one bugs hide:
+
+    age_days <= nightly_days            -> nightly
+    nightly_days < age_days <= weekly   -> weekly
+    age_days > weekly_days              -> monthly
+
+get_tier uses datetime.days (floor toward zero) so we add a few hours of slack
+to land cleanly on the intended whole-day age and avoid flakiness at midnight.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from reporium_db.scheduler import (
+    TIER_MONTHLY,
+    TIER_NIGHTLY,
+    TIER_WEEKLY,
+    get_tier,
+)
+
+
+def _pushed_days_ago(days: int, extra_hours: int = 2) -> str:
+    """ISO timestamp `days` whole days ago plus a small slack so .days == days."""
+    when = datetime.now(timezone.utc) - timedelta(days=days, hours=extra_hours)
+    return when.isoformat()
+
+
+@pytest.mark.parametrize(
+    "age_days,expected",
+    [
+        (0, TIER_NIGHTLY),    # pushed today
+        (29, TIER_NIGHTLY),   # just inside nightly
+        (30, TIER_NIGHTLY),   # exact nightly boundary is inclusive
+        (31, TIER_WEEKLY),    # first day past nightly -> weekly
+        (200, TIER_WEEKLY),   # interior weekly
+        (364, TIER_WEEKLY),   # just inside weekly
+        (365, TIER_WEEKLY),   # exact weekly boundary is inclusive
+        (366, TIER_MONTHLY),  # first day past weekly -> monthly
+        (1000, TIER_MONTHLY), # deep monthly
+    ],
+)
+def test_get_tier_default_boundaries(age_days, expected):
+    """Default thresholds (30 / 365) classify each boundary day correctly."""
+    assert get_tier(_pushed_days_ago(age_days)) == expected
+
+
+@pytest.mark.parametrize(
+    "age_days,expected",
+    [
+        (7, TIER_NIGHTLY),    # exact custom nightly boundary inclusive
+        (8, TIER_WEEKLY),     # first day past custom nightly
+        (90, TIER_WEEKLY),    # exact custom weekly boundary inclusive
+        (91, TIER_MONTHLY),   # first day past custom weekly
+    ],
+)
+def test_get_tier_custom_thresholds(age_days, expected):
+    """Custom nightly/weekly thresholds shift the boundaries accordingly."""
+    assert get_tier(_pushed_days_ago(age_days), nightly_days=7, weekly_days=90) == expected
+
+
+def test_get_tier_boundary_is_inclusive_not_exclusive():
+    """Pin the inclusivity invariant: age == nightly_days is nightly, not weekly.
+
+    Guards against a regression to a strict '<' comparison, which would push
+    every boundary-day repo down a tier and silently slow its refresh cadence.
+    """
+    exactly_nightly = _pushed_days_ago(30)
+    exactly_weekly = _pushed_days_ago(365)
+    assert get_tier(exactly_nightly) == TIER_NIGHTLY
+    assert get_tier(exactly_weekly) == TIER_WEEKLY
+    # And one day past each must drop exactly one tier.
+    assert get_tier(_pushed_days_ago(31)) == TIER_WEEKLY
+    assert get_tier(_pushed_days_ago(366)) == TIER_MONTHLY


### PR DESCRIPTION
Adds 4 unique uncommitted test files for GraphQL sync resilience from a quarantined re-clone.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>